### PR TITLE
fix ActionView::Template::Error (undefined method `title' for 1:Fixnum)

### DIFF
--- a/app/views/create_wiki_page/_init_create_wiki_page.erb
+++ b/app/views/create_wiki_page/_init_create_wiki_page.erb
@@ -1,4 +1,4 @@
-<%- if @page && User.current.allowed_to?({:controller => 'wiki', :action => 'edit'}, @project) %>
+<%- if @page && @page.kind_of?(WikiPage) && User.current.allowed_to?({:controller => 'wiki', :action => 'edit'}, @project) %>
 <script type="text/javascript">
     $(document).ready(function($) {
     if($(".wiki-page").length > 0) {


### PR DESCRIPTION
With https://github.com/pharmazone/redmine_charts2/tree/redmine21 we have a page where @page is a Fixnum => Only execute when @page is a wiki page.
